### PR TITLE
arrayToString helper

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,6 +22,7 @@ exports.expandReferences = expandReferences;
 exports.field = field;
 exports.fields = fields;
 exports.merge = merge;
+exports.index = index;
 
 var _lodashFp = require('lodash-fp');
 
@@ -330,5 +331,17 @@ function merge(dataSource, fields) {
     return initialData.reduce(function (acc, dataItem) {
       return [].concat(_toConsumableArray(acc), [_extends({}, dataItem, additionalData)]);
     }, []);
+  };
+}
+
+/**
+ * Returns the index of the current array being iterated.
+ * To be used with `each` as a data source.
+ * @constructor
+ * @returns {<DataSource>}
+ */
+function index() {
+  return function (state) {
+    return state.index;
   };
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,6 +23,7 @@ exports.field = field;
 exports.fields = fields;
 exports.merge = merge;
 exports.index = index;
+exports.arrayToString = arrayToString;
 
 var _lodashFp = require('lodash-fp');
 
@@ -39,7 +40,7 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
 /**
  * Execute a sequence of operations.
  * Main outer API for executing expressions.
- * @example 
+ * @example
  * execute(
  *   create('foo'),
  *   delete('bar')
@@ -92,7 +93,7 @@ function source(path) {
 }
 
 /**
- * Ensures a path points at the data. 
+ * Ensures a path points at the data.
  * @constructor
  * @param {string} path - JSONPath referencing a point in `data`.
  * @returns {string}
@@ -117,7 +118,7 @@ function dataValue(path) {
 }
 
 /**
- * Ensures a path points at references. 
+ * Ensures a path points at references.
  * @constructor
  * @param {string} path - JSONPath referencing a point in `references`.
  * @returns {string}
@@ -175,7 +176,7 @@ var map = exports.map = (0, _lodashFp.curry)(function (path, operation, state) {
  * Simple switcher allowing other expressions to use either a JSONPath or
  * object literals as a data source.
  * @constructor
- * @param {string|object|function} data 
+ * @param {string|object|function} data
  * - JSONPath referencing a point in `state`
  * - Object Literal of the data itself.
  * - Function to be called with state.
@@ -344,4 +345,18 @@ function index() {
   return function (state) {
     return state.index;
   };
+}
+
+/**
+ * Turns an array into a string, separated by X.
+ * @constructor
+ * @returns {<DataSource>}
+ *
+ *  field("destination_string__c", function(state) {
+ *    return Array.apply(null, dataValue("path_of_array")(state)).join(', ')
+ *  }),
+ *
+ */
+function arrayToString(arr, separator) {
+  return Array.apply(null, arr).join(separator);
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -352,11 +352,14 @@ function index() {
  * @constructor
  * @returns {<DataSource>}
  *
+ * @example <caption>Array of Values to comma separated string.</caption>
  *  field("destination_string__c", function(state) {
- *    return Array.apply(null, dataValue("path_of_array")(state)).join(', ')
- *  }),
+ *    return arrayToString(dataValue("path_of_array")(state), ', ')
+ *  })
  *
  */
-function arrayToString(arr, separator) {
+function arrayToString(arr) {
+  var separator = arguments.length <= 1 || arguments[1] === undefined ? '' : arguments[1];
+
   return Array.apply(null, arr).join(separator);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -295,3 +295,15 @@ export function merge(dataSource, fields) {
     )
   };
 }
+
+/**
+ * Returns the index of the current array being iterated.
+ * To be used with `each` as a data source.
+ * @constructor
+ * @returns {<DataSource>}
+ */
+export function index() {
+  return state => {
+    return state.index
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import JSONPath from 'JSONPath';
 /**
  * Execute a sequence of operations.
  * Main outer API for executing expressions.
- * @example 
+ * @example
  * execute(
  *   create('foo'),
  *   delete('bar')
@@ -55,7 +55,7 @@ export function source(path) {
 }
 
 /**
- * Ensures a path points at the data. 
+ * Ensures a path points at the data.
  * @constructor
  * @param {string} path - JSONPath referencing a point in `data`.
  * @returns {string}
@@ -80,7 +80,7 @@ export function dataValue(path) {
 }
 
 /**
- * Ensures a path points at references. 
+ * Ensures a path points at references.
  * @constructor
  * @param {string} path - JSONPath referencing a point in `references`.
  * @returns {string}
@@ -122,13 +122,13 @@ export const map = curry(function(path, operation, state) {
     case 'string':
       source(path)(state).map(function(data) {
         return operation({data, references: state.references});
-      });      
+      });
       return state
 
     case 'object':
       path.map(function(data) {
         return operation({data, references: state.references});
-      });      
+      });
       return state
 
   }
@@ -138,7 +138,7 @@ export const map = curry(function(path, operation, state) {
  * Simple switcher allowing other expressions to use either a JSONPath or
  * object literals as a data source.
  * @constructor
- * @param {string|object|function} data 
+ * @param {string|object|function} data
  * - JSONPath referencing a point in `state`
  * - Object Literal of the data itself.
  * - Function to be called with state.
@@ -153,7 +153,7 @@ function asData(data, state) {
       return data
     case 'function':
       return data(state)
-  }        
+  }
 }
 
 /**
@@ -239,7 +239,7 @@ export function expandReferences(obj) {
   return state => {
     return mapValues(function(value) {
       return typeof value == 'function' ? value(state) : value;
-    })(obj); 
+    })(obj);
   }
 }
 
@@ -306,4 +306,18 @@ export function index() {
   return state => {
     return state.index
   }
+}
+
+/**
+ * Turns an array into a string, separated by X.
+ * @constructor
+ * @returns {<DataSource>}
+ *
+ *  field("destination_string__c", function(state) {
+ *    return Array.apply(null, dataValue("path_of_array")(state)).join(', ')
+ *  }),
+ *
+ */
+export function arrayToString(arr, separator) {
+  return Array.apply(null, arr).join(separator)
 }

--- a/src/index.js
+++ b/src/index.js
@@ -313,11 +313,12 @@ export function index() {
  * @constructor
  * @returns {<DataSource>}
  *
+ * @example <caption>Array of Values to comma separated string.</caption>
  *  field("destination_string__c", function(state) {
- *    return Array.apply(null, dataValue("path_of_array")(state)).join(', ')
- *  }),
+ *    return arrayToString(dataValue("path_of_array")(state), ', ')
+ *  })
  *
  */
-export function arrayToString(arr, separator) {
+export function arrayToString(arr, separator='') {
   return Array.apply(null, arr).join(separator)
 }

--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,7 @@ import testData from './testData';
 import {
   execute, each, join, source, sourceValue, map, combine, field, fields,
   expandReferences, merge, dataPath, dataValue, referencePath, 
-  lastReferenceValue, index
+  lastReferenceValue, index, arrayToString
 } from '../src';
 
 describe("execute", () => {
@@ -282,4 +282,16 @@ describe("index", () => {
     expect(results.references).to.eql([0,1,2,3])
 
   })
+})
+
+describe("arrayToString", () => {
+
+  it("returns a comma separated string from an array", function() {
+    expect( arrayToString([1,2,3], ', ') ).to.eql("1, 2, 3")
+  })
+
+  it("does not require a separator", function() {
+    expect( arrayToString([1,2,3]) ).to.eql("123")
+  })
+
 })

--- a/test/index.js
+++ b/test/index.js
@@ -3,7 +3,8 @@ import testData from './testData';
 
 import {
   execute, each, join, source, sourceValue, map, combine, field, fields,
-  expandReferences, merge, dataPath, dataValue, referencePath, lastReferenceValue
+  expandReferences, merge, dataPath, dataValue, referencePath, 
+  lastReferenceValue, index
 } from '../src';
 
 describe("execute", () => {
@@ -264,5 +265,21 @@ describe("Path Helpers", () => {
       ).to.eql('bar');
 
     })
+  })
+})
+
+describe("index", () => {
+
+  it("returns the current index value of an item in `each`", () => {
+    let operation = (state) => {
+      return { ...state, references: [ ...state.references, index()(state) ] }
+    }
+
+    let results = each("$.data.store.book[*]", operation)({
+      references: [], data: testData
+    })
+
+    expect(results.references).to.eql([0,1,2,3])
+
   })
 })


### PR DESCRIPTION
@stuartc , this one is strange... i'm sure i'm doing something simple wrong here. It works like a charm in Node, and dataValue *seems* to return an array, but no love (it's just blank) when I run the expression.
```js
taylor@taylor-ThinkPad-S1-Yoga:~$ node
> arr = ["welbeck","walcott"]
[ 'welbeck', 'walcott' ]
> Array.apply(null, arr).join(" and ")
'welbeck and walcott'
> 
```
Here's the expression:
```js
person(
  fields(
    field("gender", arrayToString(dataValue("form.nick_names")," and ")),
    field("names", function(state) {
      return [{
        "givenName": dataValue("form.nick_names")(state),
        "familyName": dataValue("form.last_name")(state)
      }]
    })
  )
)
```
and that produces: `{"gender":"","names":[{"givenName":["welbeck","walcott"],"familyName":"Doe"}]}`
So it seems we get an array for `dataValue("form.nick_names")`, but when it's passed into `arrayToString(arr, separator)` we get nothing.

See `arrayToString` helper below.