### PR TITLE
Fix expand references with  null or empty objects

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -371,7 +371,7 @@ function expandReferences(value) {
       return value.map(v => expandReferences(v)(state));
     }
 
-    if (typeof value == 'object') {
+    if (typeof value == 'object' && !!value) {
       return Object.keys(value).reduce((acc, key) => {
         return { ...acc,
           [key]: expandReferences(value[key])(state)

--- a/src/index.js
+++ b/src/index.js
@@ -293,7 +293,7 @@ export function expandReferences(value) {
       return value.map(v => expandReferences(v)(state));
     }
 
-    if (typeof value == 'object') {
+    if (typeof value == 'object' && !!value) {
       return Object.keys(value).reduce((acc, key) => {
         return { ...acc, [key]: expandReferences(value[key])(state) };
       }, {});

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
-import { expect } from "chai";
-import testData from "./testData";
+import { expect } from 'chai';
+import testData from './testData';
 
 import {
   execute,
@@ -20,32 +20,32 @@ import {
   index,
   arrayToString,
   toArray,
-} from "../src";
+} from '../src';
 
-describe("execute", () => {
-  it("executes each operation in sequence", (done) => {
+describe('execute', () => {
+  it('executes each operation in sequence', done => {
     let state = {};
     let operations = [
-      (state) => {
+      state => {
         return { counter: 1 };
       },
-      (state) => {
+      state => {
         return { counter: 2 };
       },
-      (state) => {
+      state => {
         return { counter: 3 };
       },
     ];
 
     execute(...operations)(state)
-      .then((finalState) => {
+      .then(finalState => {
         expect(finalState).to.eql({ counter: 3 });
       })
       .then(done)
       .catch(done);
   });
 
-  it("returns a function that returns state", async function () {
+  it('returns a function that returns state', async function () {
     let state = {};
 
     let finalState = await execute()(state);
@@ -54,29 +54,29 @@ describe("execute", () => {
   });
 });
 
-describe("sourceValue", () => {
-  it("references a given path", () => {
-    let value = sourceValue("$.store.bicycle.color")(testData);
-    expect(value).to.eql("red");
+describe('sourceValue', () => {
+  it('references a given path', () => {
+    let value = sourceValue('$.store.bicycle.color')(testData);
+    expect(value).to.eql('red');
   });
 });
 
-describe("source", () => {
-  it("references a given path", () => {
-    let value = source("$.store.bicycle.color")(testData);
-    expect(value).to.eql(["red"]);
+describe('source', () => {
+  it('references a given path', () => {
+    let value = source('$.store.bicycle.color')(testData);
+    expect(value).to.eql(['red']);
   });
 });
 
-describe("map", () => {
-  xit("[DEPRECATED] can produce a one to one from an array", () => {
+describe('map', () => {
+  xit('[DEPRECATED] can produce a one to one from an array', () => {
     let items = [];
 
     let state = { data: testData, references: [] };
     let results = map(
-      "$.data.store.book[*]",
+      '$.data.store.book[*]',
       function (state) {
-        console.log("hello");
+        console.log('hello');
         // console.log(JSON.stringify( state ));
         // items.push( { title: sourceValue("$.data.title", state) } )
         return { references: [1, ...state.references], ...state };
@@ -85,58 +85,58 @@ describe("map", () => {
     );
 
     expect(results.references).to.eql([
-      { title: "Sayings of the Century" },
-      { title: "Sword of Honour" },
-      { title: "Moby Dick" },
-      { title: "The Lord of the Rings" },
+      { title: 'Sayings of the Century' },
+      { title: 'Sword of Honour' },
+      { title: 'Moby Dick' },
+      { title: 'The Lord of the Rings' },
     ]);
   });
 });
 
-describe("combine", () => {
+describe('combine', () => {
   let state = {};
   let operations = [
-    (state) => {
+    state => {
       return { hello: 1 };
     },
-    (state) => {
+    state => {
       return { hello: state.hello + 5 };
     },
   ];
 
-  it("accepts serveral operations, and reduces them with the state", () => {
+  it('accepts serveral operations, and reduces them with the state', () => {
     let result = combine.apply(null, operations)(state);
     expect(result).to.eql({ hello: 6 });
   });
 });
 
-describe("join", () => {
-  it("merges in a previously defined field", () => {
+describe('join', () => {
+  it('merges in a previously defined field', () => {
     let result = join(
-      "$.store.book[*]",
-      "$.store.bicycle.color",
-      "color"
+      '$.store.book[*]',
+      '$.store.bicycle.color',
+      'color'
     )(testData);
 
     expect(result[0]).to.eql({
-      author: "Nigel Rees",
-      category: "reference",
-      color: "red",
+      author: 'Nigel Rees',
+      category: 'reference',
+      color: 'red',
       price: 8.95,
-      title: "Sayings of the Century",
+      title: 'Sayings of the Century',
     });
   });
 });
 
-describe("expandReferences", () => {
-  it("resolves function values on objects", () => {
+describe('expandReferences', () => {
+  it('resolves function values on objects', () => {
     let result = expandReferences({
-      a: (s) => s,
+      a: s => s,
       // function nested inside an object inside and array
-      b: [2, { c: (s) => s + 2 }, 3],
+      b: [2, { c: s => s + 2 }, 3],
       c: 4,
       // function that returns a function
-      d: (s) => (s) => s + 4,
+      d: s => s => s + 4,
     })(1);
 
     expect(result).to.eql({
@@ -147,39 +147,51 @@ describe("expandReferences", () => {
     });
   });
 
-  it("resolves function values on arrays", () => {
-    let result = expandReferences([2, { c: (s) => s + 2 }, 3])(1);
+  it("doesn't affect empty objects", () => {
+    let result = expandReferences({})(1);
+
+    expect(result).to.eql({});
+    result = expandReferences([])(1);
+    expect(result).to.eql([]);
+    result = expandReferences(null)(1);
+    expect(result).to.eql(null);
+    result = expandReferences(undefined)(1);
+    expect(result).to.eql(undefined);
+  });
+
+  it('resolves function values on arrays', () => {
+    let result = expandReferences([2, { c: s => s + 2 }, 3])(1);
 
     expect(result).to.eql([2, { c: 3 }, 3]);
   });
 });
 
-describe("field", () => {
-  it("returns a pair", () => {
-    expect(field("a", 1)).to.eql(["a", 1]);
+describe('field', () => {
+  it('returns a pair', () => {
+    expect(field('a', 1)).to.eql(['a', 1]);
   });
 });
 
-describe("fields", () => {
-  it("returns an object", () => {
-    expect(fields(["a", 1], ["b", 2])).to.eql({ a: 1, b: 2 });
+describe('fields', () => {
+  it('returns an object', () => {
+    expect(fields(['a', 1], ['b', 2])).to.eql({ a: 1, b: 2 });
   });
 });
 
-describe("merge", () => {
-  it("merges in a set of fields from data, for an array of sources", () => {
+describe('merge', () => {
+  it('merges in a set of fields from data, for an array of sources', () => {
     let result = merge(
-      "$.store.book[*]",
+      '$.store.book[*]',
       fields(
-        field("color", sourceValue("$.store.bicycle.color")),
-        field("price", sourceValue("$.store.bicycle.price"))
+        field('color', sourceValue('$.store.bicycle.color')),
+        field('price', sourceValue('$.store.bicycle.price'))
       )
     )(testData);
 
-    expect(result[0].color).to.eql("red");
-    expect(result[1].color).to.eql("red");
-    expect(result[2].color).to.eql("red");
-    expect(result[3].color).to.eql("red");
+    expect(result[0].color).to.eql('red');
+    expect(result[1].color).to.eql('red');
+    expect(result[2].color).to.eql('red');
+    expect(result[3].color).to.eql('red');
 
     expect(result[0].price).to.eql(19.95);
     expect(result[1].price).to.eql(19.95);
@@ -188,47 +200,47 @@ describe("merge", () => {
   });
 });
 
-describe("Path Helpers", () => {
-  describe("dataPath", () => {
-    it("prepends source data paths with $.data", () => {
-      expect(dataPath("data.hello")).to.eql("$.data.data.hello");
-      expect(dataPath("$.data.hello")).to.eql("$.data.data.hello");
+describe('Path Helpers', () => {
+  describe('dataPath', () => {
+    it('prepends source data paths with $.data', () => {
+      expect(dataPath('data.hello')).to.eql('$.data.data.hello');
+      expect(dataPath('$.data.hello')).to.eql('$.data.data.hello');
       // TODO: should we expect it to handle arrays like this...
       // expect(dataPath("[0].foo")).to.eql("$.data[0].foo")
       // Or like this...
-      expect(dataPath("[0].foo")).to.eql("$.data.[0].foo");
+      expect(dataPath('[0].foo')).to.eql('$.data.[0].foo');
     });
   });
-  describe("dataValue", () => {
-    it("references a given path inside $.data", () => {
-      let value = dataValue("store.bicycle.color")({ data: testData });
-      expect(value).to.eql("red");
+  describe('dataValue', () => {
+    it('references a given path inside $.data', () => {
+      let value = dataValue('store.bicycle.color')({ data: testData });
+      expect(value).to.eql('red');
     });
   });
-  describe("referencePath", () => {
-    it("prepends a paths with $.references", () => {
-      expect(referencePath("[0]")).to.eql("$.references[0]");
+  describe('referencePath', () => {
+    it('prepends a paths with $.references', () => {
+      expect(referencePath('[0]')).to.eql('$.references[0]');
     });
   });
-  describe("lastReferenceValue", () => {
-    it("returns the last reference in `state.references`", () => {
+  describe('lastReferenceValue', () => {
+    it('returns the last reference in `state.references`', () => {
       expect(
-        lastReferenceValue("foo")({
-          references: [{ foo: "bar" }, { baz: "foo" }],
+        lastReferenceValue('foo')({
+          references: [{ foo: 'bar' }, { baz: 'foo' }],
         })
-      ).to.eql("bar");
+      ).to.eql('bar');
     });
   });
 });
 
-describe("index", function () {
-  it("returns the current index value of an item in `each`", () => {
-    let operation = (state) => {
+describe('index', function () {
+  it('returns the current index value of an item in `each`', () => {
+    let operation = state => {
       return { ...state, references: [...state.references, index()(state)] };
     };
 
     let results = each(
-      "$.data.store.book[*]",
+      '$.data.store.book[*]',
       operation
     )({
       references: [],
@@ -239,26 +251,26 @@ describe("index", function () {
   });
 });
 
-describe("arrayToString", function () {
-  it("returns a comma separated string from an array", function () {
-    expect(arrayToString([1, 2, 3], ", ")).to.eql("1, 2, 3");
+describe('arrayToString', function () {
+  it('returns a comma separated string from an array', function () {
+    expect(arrayToString([1, 2, 3], ', ')).to.eql('1, 2, 3');
   });
 
-  it("does not require a separator", function () {
-    expect(arrayToString([1, 2, 3])).to.eql("123");
+  it('does not require a separator', function () {
+    expect(arrayToString([1, 2, 3])).to.eql('123');
   });
 });
 
-describe("toArray", function () {
-  it("leaves arrays untouched", function () {
+describe('toArray', function () {
+  it('leaves arrays untouched', function () {
     expect(toArray([1, 2, 3])).to.eql([1, 2, 3]);
   });
 
-  it("wraps objects in an array", function () {
+  it('wraps objects in an array', function () {
     expect(toArray({ a: 1 })).to.eql([{ a: 1 }]);
   });
 
-  it("wraps strings in an array", function () {
-    expect(toArray("a")).to.eql(["a"]);
+  it('wraps strings in an array', function () {
+    expect(toArray('a')).to.eql(['a']);
   });
 });


### PR DESCRIPTION
This PR fixes expand references for empty objects such as `{}` , `null`, `undefined`, and `[]`.