### PR TITLE
Replacing emojis with replacement character

### DIFF
--- a/ast.json
+++ b/ast.json
@@ -903,7 +903,7 @@
         "str"
       ],
       "docs": {
-        "description": "Subsitutes underscores for spaces and proper-cases a string",
+        "description": "Substitutes underscores for spaces and proper-cases a string",
         "tags": [
           {
             "title": "public",
@@ -947,7 +947,7 @@
         "replacementChars"
       ],
       "docs": {
-        "description": "Replaces emojis in a string with other replacement characters given as input.",
+        "description": "Replaces emojis in a string.",
         "tags": [
           {
             "title": "public",
@@ -974,7 +974,7 @@
           },
           {
             "title": "param",
-            "description": "Characters that replaces the emojis",
+            "description": "Characters that replace the emojis",
             "type": {
               "type": "NameExpression",
               "name": "string"

--- a/ast.json
+++ b/ast.json
@@ -944,10 +944,10 @@
       "name": "scrubEmojis",
       "params": [
         "text",
-        "replacementChar"
+        "replacementChars"
       ],
       "docs": {
-        "description": "Removes emojis from a string of text by replacing them with a replacement characters",
+        "description": "Replaces emojis in a string with other replacement characters given as input.",
         "tags": [
           {
             "title": "public",
@@ -974,12 +974,12 @@
           },
           {
             "title": "param",
-            "description": "Character that replaces emojis",
+            "description": "Characters that replaces the emojis",
             "type": {
               "type": "NameExpression",
               "name": "string"
             },
-            "name": "replacementChar"
+            "name": "replacementChars"
           },
           {
             "title": "returns",

--- a/ast.json
+++ b/ast.json
@@ -941,12 +941,13 @@
       "valid": true
     },
     {
-      "name": "removeEmojis",
+      "name": "scrubEmojis",
       "params": [
-        "text"
+        "text",
+        "replacementChar"
       ],
       "docs": {
-        "description": "Removes emojis from a string of text",
+        "description": "Removes emojis from a string of text by replacing them with a replacement characters",
         "tags": [
           {
             "title": "public",
@@ -955,7 +956,7 @@
           },
           {
             "title": "example",
-            "description": "removeEmojis('Dove🕊️⭐ 29')"
+            "description": "scrubEmojis('Dove🕊️⭐ 29')"
           },
           {
             "title": "function",
@@ -970,6 +971,15 @@
               "name": "string"
             },
             "name": "text"
+          },
+          {
+            "title": "param",
+            "description": "Character that replaces emojis",
+            "type": {
+              "type": "NameExpression",
+              "name": "string"
+            },
+            "name": "replacementChar"
           },
           {
             "title": "returns",

--- a/lib/Adaptor.js
+++ b/lib/Adaptor.js
@@ -26,7 +26,7 @@ exports.toArray = toArray;
 exports.composeNextState = composeNextState;
 exports.humanProper = humanProper;
 exports.splitKeys = splitKeys;
-exports.removeEmojis = removeEmojis;
+exports.scrubEmojis = scrubEmojis;
 exports.http = exports.beta = exports.map = void 0;
 
 var _fp = require("lodash/fp");
@@ -569,18 +569,20 @@ function splitKeys(obj, keys) {
   }, [{}, {}]);
 }
 /**
- * Removes emojis from a string of text
+ * Removes emojis from a string of text by replacing them with a replacement characters
  * @public
  * @example
- * removeEmojis('Dove🕊️⭐ 29')
+ * scrubEmojis('Dove🕊️⭐ 29')
  * @function
  * @param {string} text - String that needs to be cleaned
+ * @param {string} replacementChar - Character that replaces emojis
  * @returns {string}
  */
 
 
-function removeEmojis(text) {
+function scrubEmojis(text, replacementChar) {
   if (!text) return text;
+  if (!replacementChar) replacementChar = '\uFFFD';
   const emojisPattern = /(\uFE0F|\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])/g;
-  return text.replace(emojisPattern, '');
+  return text.replace(emojisPattern, replacementChar);
 }

--- a/lib/Adaptor.js
+++ b/lib/Adaptor.js
@@ -583,6 +583,7 @@ function splitKeys(obj, keys) {
 function scrubEmojis(text, replacementChar) {
   if (!text) return text;
   if (!replacementChar) replacementChar = '\uFFFD';
+  if (replacementChar = '') console.warn("Removing characters from a string may create injection vulnerabilities. It's better to replace than remove.");
   const emojisPattern = /(\uFE0F|\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])/g;
   return text.replace(emojisPattern, replacementChar);
 }

--- a/lib/Adaptor.js
+++ b/lib/Adaptor.js
@@ -569,21 +569,21 @@ function splitKeys(obj, keys) {
   }, [{}, {}]);
 }
 /**
- * Removes emojis from a string of text by replacing them with a replacement characters
+ * Replaces emojis in a string with other replacement characters given as input.
  * @public
  * @example
  * scrubEmojis('Dove🕊️⭐ 29')
  * @function
  * @param {string} text - String that needs to be cleaned
- * @param {string} replacementChar - Character that replaces emojis
+ * @param {string} replacementChars - Characters that replaces the emojis
  * @returns {string}
  */
 
 
-function scrubEmojis(text, replacementChar) {
+function scrubEmojis(text, replacementChars) {
   if (!text) return text;
-  if (!replacementChar) replacementChar = '\uFFFD';
-  if (replacementChar = '') console.warn("Removing characters from a string may create injection vulnerabilities. It's better to replace than remove.");
+  if (!replacementChars) replacementChars = '\uFFFD';
+  if (replacementChars == '') console.warn("Removing characters from a string may create injection vulnerabilities. It's better to replace than remove. See http://www.unicode.org/reports/tr36/#Deletion_of_Noncharacters");
   const emojisPattern = /(\uFE0F|\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])/g;
-  return text.replace(emojisPattern, replacementChar);
+  return text.replace(emojisPattern, replacementChars);
 }

--- a/lib/Adaptor.js
+++ b/lib/Adaptor.js
@@ -533,7 +533,7 @@ function composeNextState(state, response) {
   };
 }
 /**
- * Subsitutes underscores for spaces and proper-cases a string
+ * Substitutes underscores for spaces and proper-cases a string
  * @public
  * @example
  * field("destination_string__c", humanProper(state.data.path_to_string))
@@ -569,13 +569,13 @@ function splitKeys(obj, keys) {
   }, [{}, {}]);
 }
 /**
- * Replaces emojis in a string with other replacement characters given as input.
+ * Replaces emojis in a string.
  * @public
  * @example
  * scrubEmojis('Dove🕊️⭐ 29')
  * @function
  * @param {string} text - String that needs to be cleaned
- * @param {string} replacementChars - Characters that replaces the emojis
+ * @param {string} replacementChars - Characters that replace the emojis
  * @returns {string}
  */
 
@@ -583,7 +583,7 @@ function splitKeys(obj, keys) {
 function scrubEmojis(text, replacementChars) {
   if (!text) return text;
   if (!replacementChars) replacementChars = '\uFFFD';
-  if (replacementChars == '') console.warn("Removing characters from a string may create injection vulnerabilities. It's better to replace than remove. See http://www.unicode.org/reports/tr36/#Deletion_of_Noncharacters");
+  if (replacementChars == '') console.warn('Removing characters from a string may create injection vulnerabilities;', "It's better to replace than remove.", 'See https://www.unicode.org/reports/tr36/#Deletion_of_Noncharacters');
   const emojisPattern = /(\uFE0F|\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])/g;
   return text.replace(emojisPattern, replacementChars);
 }

--- a/src/Adaptor.js
+++ b/src/Adaptor.js
@@ -488,6 +488,10 @@ export function splitKeys(obj, keys) {
 export function scrubEmojis(text, replacementChar) {
   if (!text) return text;
   if (!replacementChar) replacementChar = '\uFFFD';
+  if ((replacementChar = ''))
+    console.warn(
+      "Removing characters from a string may create injection vulnerabilities. It's better to replace than remove."
+    );
   const emojisPattern = /(\uFE0F|\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])/g;
   return text.replace(emojisPattern, replacementChar);
 }

--- a/src/Adaptor.js
+++ b/src/Adaptor.js
@@ -476,22 +476,22 @@ export function splitKeys(obj, keys) {
 }
 
 /**
- * Removes emojis from a string of text by replacing them with a replacement characters
+ * Replaces emojis in a string with other replacement characters given as input.
  * @public
  * @example
  * scrubEmojis('Dove🕊️⭐ 29')
  * @function
  * @param {string} text - String that needs to be cleaned
- * @param {string} replacementChar - Character that replaces emojis
+ * @param {string} replacementChars - Characters that replaces the emojis
  * @returns {string}
  */
-export function scrubEmojis(text, replacementChar) {
+export function scrubEmojis(text, replacementChars) {
   if (!text) return text;
-  if (!replacementChar) replacementChar = '\uFFFD';
-  if ((replacementChar = ''))
+  if (!replacementChars) replacementChars = '\uFFFD';
+  if (replacementChars == '')
     console.warn(
-      "Removing characters from a string may create injection vulnerabilities. It's better to replace than remove."
+      "Removing characters from a string may create injection vulnerabilities. It's better to replace than remove. See http://www.unicode.org/reports/tr36/#Deletion_of_Noncharacters"
     );
   const emojisPattern = /(\uFE0F|\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])/g;
-  return text.replace(emojisPattern, replacementChar);
+  return text.replace(emojisPattern, replacementChars);
 }

--- a/src/Adaptor.js
+++ b/src/Adaptor.js
@@ -442,7 +442,7 @@ export function composeNextState(state, response) {
 }
 
 /**
- * Subsitutes underscores for spaces and proper-cases a string
+ * Substitutes underscores for spaces and proper-cases a string
  * @public
  * @example
  * field("destination_string__c", humanProper(state.data.path_to_string))
@@ -476,22 +476,27 @@ export function splitKeys(obj, keys) {
 }
 
 /**
- * Replaces emojis in a string with other replacement characters given as input.
+ * Replaces emojis in a string.
  * @public
  * @example
  * scrubEmojis('Dove🕊️⭐ 29')
  * @function
  * @param {string} text - String that needs to be cleaned
- * @param {string} replacementChars - Characters that replaces the emojis
+ * @param {string} replacementChars - Characters that replace the emojis
  * @returns {string}
  */
 export function scrubEmojis(text, replacementChars) {
   if (!text) return text;
   if (!replacementChars) replacementChars = '\uFFFD';
+
   if (replacementChars == '')
     console.warn(
-      "Removing characters from a string may create injection vulnerabilities. It's better to replace than remove. See http://www.unicode.org/reports/tr36/#Deletion_of_Noncharacters"
+      'Removing characters from a string may create injection vulnerabilities;',
+      "It's better to replace than remove.",
+      'See https://www.unicode.org/reports/tr36/#Deletion_of_Noncharacters'
     );
+
   const emojisPattern = /(\uFE0F|\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])/g;
+
   return text.replace(emojisPattern, replacementChars);
 }

--- a/src/Adaptor.js
+++ b/src/Adaptor.js
@@ -479,16 +479,15 @@ export function splitKeys(obj, keys) {
  * Removes emojis from a string of text by replacing them with a replacement characters
  * @public
  * @example
- * scrubEmojis('Dove🕊️⭐ 29') // Replaces emojis with default replacement character. This is what we indicate.
- * scrubEmojis('Dove🕊️⭐ 29', '') // Replaces emojis with empty string. This is dangerous and can introduce security vulnerabilities
- * scrubEmojis('Dove🕊️⭐ 29', 'a') // Replaces emojis with the character 'a'
+ * scrubEmojis('Dove🕊️⭐ 29')
  * @function
  * @param {string} text - String that needs to be cleaned
  * @param {string} replacementChar - Character that replaces emojis
  * @returns {string}
  */
-export function scrubEmojis(text, replacementChar = '\uFFFD') {
+export function scrubEmojis(text, replacementChar) {
   if (!text) return text;
+  if (!replacementChar) replacementChar = '\uFFFD';
   const emojisPattern = /(\uFE0F|\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])/g;
   return text.replace(emojisPattern, replacementChar);
 }

--- a/src/Adaptor.js
+++ b/src/Adaptor.js
@@ -476,16 +476,19 @@ export function splitKeys(obj, keys) {
 }
 
 /**
- * Removes emojis from a string of text
+ * Removes emojis from a string of text by replacing them with a replacement characters
  * @public
  * @example
- * removeEmojis('Dove🕊️⭐ 29')
+ * scrubEmojis('Dove🕊️⭐ 29') // Replaces emojis with default replacement character. This is what we indicate.
+ * scrubEmojis('Dove🕊️⭐ 29', '') // Replaces emojis with empty string. This is dangerous and can introduce security vulnerabilities
+ * scrubEmojis('Dove🕊️⭐ 29', 'a') // Replaces emojis with the character 'a'
  * @function
  * @param {string} text - String that needs to be cleaned
+ * @param {string} replacementChar - Character that replaces emojis
  * @returns {string}
  */
-export function removeEmojis(text) {
+export function scrubEmojis(text, replacementChar = '\uFFFD') {
   if (!text) return text;
   const emojisPattern = /(\uFE0F|\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])/g;
-  return text.replace(emojisPattern, '');
+  return text.replace(emojisPattern, replacementChar);
 }

--- a/test/index.js
+++ b/test/index.js
@@ -296,7 +296,7 @@ describe('splitKeys', function () {
   });
 });
 
-describe('removeEmojis', function () {
+describe('scrubEmojis', function () {
   it('should remove the dove and the star', function () {
     const withEmojis = 'This is a dove🕊️⭐_29 Jul 2021';
     const withoutEmojis = 'This is a dove���_29 Jul 2021';

--- a/test/index.js
+++ b/test/index.js
@@ -306,7 +306,7 @@ describe('scrubEmojis', function () {
   it('should remove the dove', function () {
     const withEmoji = 'This is a dove🕊️_29 Jul 2021';
     const withoutEmoji = 'This is a dove��_29 Jul 2021';
-    assert.equal(unescape(scrubEmojis(withEmoji)), withoutEmoji);
+    assert.equal(scrubEmojis(withEmoji), withoutEmoji);
   });
 
   it('should remove the star', function () {

--- a/test/index.js
+++ b/test/index.js
@@ -22,7 +22,12 @@ import {
   splitKeys,
   toArray,
 } from '../src';
-import { getCharCodes, removeEmojis, removeWeirdSpaces } from '../src/Adaptor';
+import {
+  getCharCodes,
+  removeEmojis,
+  removeWeirdSpaces,
+  scrubEmojis,
+} from '../src/Adaptor';
 
 describe('execute', () => {
   it('executes each operation in sequence', done => {
@@ -294,35 +299,35 @@ describe('splitKeys', function () {
 describe('removeEmojis', function () {
   it('should remove the dove and the star', function () {
     const withEmojis = 'This is a dove🕊️⭐_29 Jul 2021';
-    const withoutEmojis = 'This is a dove_29 Jul 2021';
-    assert.equal(removeEmojis(withEmojis), withoutEmojis);
+    const withoutEmojis = 'This is a dove���_29 Jul 2021';
+    assert.equal(scrubEmojis(withEmojis), withoutEmojis);
   });
 
   it('should remove the dove', function () {
     const withEmoji = 'This is a dove🕊️_29 Jul 2021';
-    const withoutEmoji = 'This is a dove_29 Jul 2021';
-    assert.equal(removeEmojis(withEmoji), withoutEmoji);
+    const withoutEmoji = 'This is a dove��_29 Jul 2021';
+    assert.equal(unescape(scrubEmojis(withEmoji)), withoutEmoji);
   });
 
   it('should remove the star', function () {
     const withEmoji = 'This is a star⭐_29 Jul 2021';
-    const withoutEmoji = 'This is a star_29 Jul 2021';
-    assert.equal(removeEmojis(withEmoji), withoutEmoji);
+    const withoutEmoji = 'This is a star�_29 Jul 2021';
+    assert.equal(scrubEmojis(withEmoji), withoutEmoji);
   });
 
   it('should remove the emoji and the variant code', function () {
     const withEmoji = 'This is a star⭐ ️ 2021-07-29';
-    const withoutEmoji = 'This is a star  2021-07-29';
-    assert.equal(removeEmojis(withEmoji), withoutEmoji);
+    const withoutEmoji = 'This is a star� � 2021-07-29';
+    assert.equal(scrubEmojis(withEmoji), withoutEmoji);
   });
 
   it("should return input if input doesn't have emojis", function () {
     const withoutEmojis = 'This is a dove_29 Jul 2021';
-    assert.equal(removeEmojis(withoutEmojis), withoutEmojis);
+    assert.equal(scrubEmojis(withoutEmojis), withoutEmojis);
   });
 
   it('should return input if input is falsy', function () {
     const noText = undefined;
-    assert.equal(removeEmojis(noText), noText);
+    assert.equal(scrubEmojis(noText), noText);
   });
 });


### PR DESCRIPTION
We, now, use the replacement character (U+FFFD) to replace all the emojis.
We also allow to chose a specific replacement character if needed and pass it as parameter to the function.
This refactored, to fix potential security vulnerability in replacing with empty string