### PR TITLE
allow authors to exit jobs with arbitrary exit codes

### DIFF
--- a/ast.json
+++ b/ast.json
@@ -1047,6 +1047,41 @@
       "valid": true
     },
     {
+      "name": "exit",
+      "params": [
+        "code"
+      ],
+      "docs": {
+        "description": "Allows to exit a job with a custom code.",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "example",
+            "description": "exit(42)"
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "param",
+            "description": "Code to exit with.",
+            "type": {
+              "type": "NameExpression",
+              "name": "Integer"
+            },
+            "name": "code"
+          }
+        ]
+      },
+      "valid": true
+    },
+    {
       "name": "map",
       "params": [
         "path",

--- a/ast.json
+++ b/ast.json
@@ -1052,7 +1052,7 @@
         "code"
       ],
       "docs": {
-        "description": "Allows to exit a job with a custom code.",
+        "description": "Allows authors to exit jobs at any time with an arbitrary exit code.",
         "tags": [
           {
             "title": "public",

--- a/lib/Adaptor.js
+++ b/lib/Adaptor.js
@@ -28,6 +28,7 @@ exports.humanProper = humanProper;
 exports.splitKeys = splitKeys;
 exports.scrubEmojis = scrubEmojis;
 exports.chunk = chunk;
+exports.exit = exit;
 exports.dateFns = exports.http = exports.beta = exports.map = void 0;
 
 var _fp = require("lodash/fp");
@@ -613,4 +614,17 @@ function chunk(array, chunkSize) {
   for (var i = 0, len = array.length; i < len; i += chunkSize) output.push(array.slice(i, i + chunkSize));
 
   return output;
+}
+/**
+ * Allows to exit a job with a custom code.
+ * @public
+ * @example
+ * exit(42)
+ * @function
+ * @param {Integer} code - Code to exit with.
+ */
+
+
+function exit(code) {
+  process.exit(code);
 }

--- a/lib/Adaptor.js
+++ b/lib/Adaptor.js
@@ -616,7 +616,7 @@ function chunk(array, chunkSize) {
   return output;
 }
 /**
- * Allows to exit a job with a custom code.
+ * Allows authors to exit jobs at any time with an arbitrary exit code.
  * @public
  * @example
  * exit(42)

--- a/src/Adaptor.js
+++ b/src/Adaptor.js
@@ -519,7 +519,7 @@ export function chunk(array, chunkSize) {
 }
 
 /**
- * Allows to exit a job with a custom code.
+ * Allows authors to exit jobs at any time with an arbitrary exit code.
  * @public
  * @example
  * exit(42)

--- a/src/Adaptor.js
+++ b/src/Adaptor.js
@@ -517,3 +517,15 @@ export function chunk(array, chunkSize) {
     output.push(array.slice(i, i + chunkSize));
   return output;
 }
+
+/**
+ * Allows to exit a job with a custom code.
+ * @public
+ * @example
+ * exit(42)
+ * @function
+ * @param {Integer} code - Code to exit with.
+ */
+export function exit(code) {
+  process.exit(code);
+}


### PR DESCRIPTION
We had a situation in a client implementation where we had 5 operations in the same job. 
But we had to `NOT EXECUTE` any of the 5 operations if we received a certain `username`. Throwing an error was not an option either. So we need to allow the user to exit the job with a specific code.

Using `process.exit(0)` would allow us to exit as the exit code might be also relevant in platform.

This new helper function can be used to do so but we are not yet sure of the security implications.

example of usage
```js
fn(state => {
  if (true) {
    console.log('exiting');
    exit(1);
  }
  console.log('keep going')
  return state;
});
```

**EDIT: Are there any exit code that we might want to avoid as parameters?**