### PR TITLE
custom exit code

### DIFF
--- a/ast.json
+++ b/ast.json
@@ -79,6 +79,41 @@
       "valid": true
     },
     {
+      "name": "exit",
+      "params": [
+        "code"
+      ],
+      "docs": {
+        "description": "Allows authors to exit jobs at any time with an arbitrary exit code.",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "example",
+            "description": "exit(42);"
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "param",
+            "description": "is the exit code",
+            "type": {
+              "type": "NameExpression",
+              "name": "Integer"
+            },
+            "name": "code"
+          }
+        ]
+      },
+      "valid": true
+    },
+    {
       "name": "sourceValue",
       "params": [
         "path"

--- a/lib/Adaptor.js
+++ b/lib/Adaptor.js
@@ -6,6 +6,7 @@ Object.defineProperty(exports, "__esModule", {
 exports.execute = execute;
 exports.alterState = alterState;
 exports.fn = fn;
+exports.exit = exit;
 exports.sourceValue = sourceValue;
 exports.source = source;
 exports.dataPath = dataPath;
@@ -100,6 +101,20 @@ function fn(func) {
   return state => {
     return func(state);
   };
+}
+/**
+ * Allows authors to exit jobs at any time with an arbitrary exit code.
+ * @public
+ * @example
+ * exit(42);
+ * @function
+ * @param {Integer} code is the exit code
+ * @returns {<Operation>}
+ */
+
+
+function exit(code) {
+  return () => process.exit(code);
 }
 /**
  * Picks out a single value from source data.

--- a/src/Adaptor.js
+++ b/src/Adaptor.js
@@ -56,6 +56,19 @@ export function fn(func) {
 }
 
 /**
+ * Allows authors to exit jobs at any time with an arbitrary exit code.
+ * @public
+ * @example
+ * exit(42);
+ * @function
+ * @param {Integer} code is the exit code
+ * @returns {<Operation>}
+ */
+export function exit(code) {
+  return () => process.exit(code);
+}
+
+/**
  * Picks out a single value from source data.
  * If a JSONPath returns more than one value for the reference, the first
  * item will be returned.


### PR DESCRIPTION
@stuartc , we talked about this today and i found an old PR from @lakhassane (https://github.com/OpenFn/language-common/pull/32) that's essentially the same concept. it would be super useful for filters on platform or lightning if authors could set their own exit codes... and we could build standard patterns around `42` for a no-op, for example. as we shift from elixir/jsonb triggers to "infinite triggers" in javascript, the ability to arbitrarily exit a run _and not have subsequent flow jobs NOT get fired_ will be important.

Could we establish that lightning will treat 0 as success, 1 as failure, 2 as timeout, 42 as no-op (no flows are triggered), etc.?